### PR TITLE
Minor bug fix: Pass copies of params into the test, instead of the originals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ------
 
+## [v2.0.1](https://github.com/asfadmin/Discovery-PytestAutomation/compare/v2.0.0...v2.0.1)
+
+### Fixed:
+- Pass **copies** of params into the test, so that they can't modify the params before `repr_failure` is called on test cleanup.
+
+------
+
 ## [v2.0.0](https://github.com/asfadmin/Discovery-PytestAutomation/compare/v1.1.2...v2.0.0)
 
 ### Breaking Change:

--- a/automation/yamlfile.py
+++ b/automation/yamlfile.py
@@ -1,6 +1,7 @@
 import os # path
 import pytest # File, Item
 import warnings # warn
+import copy # copy
 
 from automation import helpers
 
@@ -56,7 +57,11 @@ class YamlItem(pytest.Item):
                 # Check if you're supposed to run it:
                 helpers.skipTestsIfNecessary(config=self.config, test_name=self.test_info["title"], file_name=self.file_name, test_type=self.test_type_name)
                 # Run the test!!!
-                poss_test_type["method_pointer"](test_info=self.test_info, config=self.config, test_type_vars=poss_test_type["variables"])
+                poss_test_type["method_pointer"](
+                    test_info=copy.copy(self.test_info),
+                    config=copy.copy(self.config),
+                    test_type_vars=copy.copy(poss_test_type["variables"]),
+                )
                 # You're done. Don't check ALL test types, only the FIRST match
                 break
         assert found_test, "TEST TYPE NOT FOUND: Could not find which 'test_types' element in pytest-config.yml to use with this test."


### PR DESCRIPTION
Stops tests from deleting keys from `test_info`, that the plugin is expecting to use later on in the run.