### PR TITLE
v3.0.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ------
 
+## [v3.0.0](https://github.com/asfadmin/Discovery-PytestAutomation/compare/v2.0.1...v3.0.0)
+
+### Breaking Change:
+- Upgraded to pytest-8. **Plugin will now only work with pytest>=8.0.0**.
+
+### Fixed:
+- Completely removes legacy dependency from requirements.txt (`py` package) per cve advisory https://github.com/advisories/GHSA-w596-4wvx-j9j6
+
+------
+
 ## [v2.0.1](https://github.com/asfadmin/Discovery-PytestAutomation/compare/v2.0.0...v2.0.1)
 
 ### Fixed:

--- a/automation/helpers.py
+++ b/automation/helpers.py
@@ -12,7 +12,6 @@ from types import ModuleType
 from _pytest.config import Config
 
 import os
-import re
 import fnmatch
 
 # Returns true if any "section" (any part between /, "section1/section2/..."),

--- a/automation/plugin.py
+++ b/automation/plugin.py
@@ -6,7 +6,6 @@ import pathlib
 # For type hints only:
 from pytest import Session, File
 from _pytest.config.argparsing import Parser
-from py._path.local import LocalPath
 from _pytest.nodes import Collector
 
 # Runs once at the start of everything:
@@ -46,6 +45,8 @@ def pytest_addoption(parser: Parser) -> None:
         help = "Skips ALL the tests. (Added for pipeline use).")
 
 # Based on: https://docs.pytest.org/en/6.2.x/example/nonpython.html
-def pytest_collect_file(parent: Collector, path: LocalPath) -> File:
-    if path.ext in [".yml", ".yaml"] and path.basename.startswith("test_"):
-        return yamlfile.YamlFile.from_parent(parent, path=pathlib.Path(path))
+# path is deprecated, using file_path
+# https://docs.pytest.org/en/7.1.x/reference/reference.html#pytest_collect_file
+def pytest_collect_file(parent: Collector, file_path: pathlib.Path) -> File:
+    if file_path.suffix in [".yml", ".yaml"] and file_path.name.startswith("test_"):
+        return yamlfile.YamlFile.from_parent(parent, path=file_path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
-attrs==21.4.0
-iniconfig==1.1.1
-pluggy==1.0.0
-py==1.11.0
-pyparsing==3.0.9
-pytest==7.1.2
-PyYAML==6.0
-toml==0.10.2
+exceptiongroup==1.2.1
+iniconfig==2.0.0
+packaging==24.0
+pluggy==1.5.0
+pytest==8.1.1
+PyYAML==6.0.1
 tomli==2.0.1


### PR DESCRIPTION
### Breaking Change:
- Upgraded to pytest-8. **Plugin will now only work with pytest>=8.0.0**.

### Fixed:
- Completely removes legacy dependency from requirements.txt (`py` package) per cve advisory https://github.com/advisories/GHSA-w596-4wvx-j9j6
- Removes unused dependencies
------